### PR TITLE
Add POS sale interconnector skeleton

### DIFF
--- a/pos_sale_interconnector/README.rst
+++ b/pos_sale_interconnector/README.rst
@@ -1,0 +1,25 @@
+POS Sale Interconnector
+=======================
+
+This module provides a basic skeleton for synchronizing product catalog and POS
+sales between a central Odoo instance and remote store databases.
+
+Features
+--------
+* Push updated products and prices from the central database to stores.
+* Import ``pos.order`` records from stores and transform them into confirmed
+  ``sale.order`` records on the central instance using a dedicated warehouse.
+
+Configuration
+-------------
+Create ``store.connector`` records for each remote store. Specify the remote
+URL, database name and credentials as well as the warehouse representing the
+store.
+
+Usage
+-----
+Run ``sync_products`` to send product data to stores and ``import_pos_orders``
+to fetch sales.
+
+The methods are provided as starting points and should be extended with
+real synchronization logic depending on the environment.

--- a/pos_sale_interconnector/__init__.py
+++ b/pos_sale_interconnector/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/pos_sale_interconnector/__manifest__.py
+++ b/pos_sale_interconnector/__manifest__.py
@@ -1,0 +1,12 @@
+{
+    "name": "POS Sale Interconnector",
+    "version": "18.0.1.0.0",
+    "summary": "Sync products and POS sales between central and stores",
+    "author": "Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "category": "Tools",
+    "depends": ["sale_management", "point_of_sale", "stock"],
+    "data": [
+    ],
+    "installable": True,
+}

--- a/pos_sale_interconnector/models/__init__.py
+++ b/pos_sale_interconnector/models/__init__.py
@@ -1,0 +1,1 @@
+from . import interconnector

--- a/pos_sale_interconnector/models/interconnector.py
+++ b/pos_sale_interconnector/models/interconnector.py
@@ -1,0 +1,74 @@
+from odoo import api, fields, models
+from odoo.exceptions import UserError
+import xmlrpc.client
+
+
+class StoreConnector(models.Model):
+    _name = "store.connector"
+    _description = "Remote store connection"
+
+    name = fields.Char(required=True)
+    url = fields.Char(required=True)
+    db_name = fields.Char(required=True)
+    username = fields.Char(required=True)
+    password = fields.Char(required=True)
+    warehouse_id = fields.Many2one("stock.warehouse", required=True)
+
+    def _get_rpc_client(self):
+        self.ensure_one()
+        common = xmlrpc.client.ServerProxy(f"{self.url}/xmlrpc/2/common")
+        uid = common.authenticate(self.db_name, self.username, self.password, {})
+        if not uid:
+            raise UserError("Authentication failed for %s" % self.name)
+        models = xmlrpc.client.ServerProxy(f"{self.url}/xmlrpc/2/object")
+        return uid, models
+
+    def sync_products(self):
+        """Push updated products to remote store"""
+        uid, models = self._get_rpc_client()
+        products = self.env["product.product"].search([("write_date", ">", fields.Datetime.to_datetime('1970-01-01'))])
+        for product in products:
+            vals = {
+                "name": product.name,
+                "list_price": product.lst_price,
+            }
+            models.execute_kw(
+                self.db_name,
+                uid,
+                self.password,
+                "product.product",
+                "create",
+                [vals],
+            )
+
+    def import_pos_orders(self):
+        """Import POS orders from remote store as confirmed sale orders"""
+        uid, models = self._get_rpc_client()
+        domain = [["state", "=", "paid"]]
+        order_ids = models.execute_kw(
+            self.db_name,
+            uid,
+            self.password,
+            "pos.order",
+            "search",
+            [domain],
+        )
+        orders = models.execute_kw(
+            self.db_name,
+            uid,
+            self.password,
+            "pos.order",
+            "read",
+            [order_ids],
+        )
+        SaleOrder = self.env["sale.order"]
+        for order in orders:
+            partner = self.env["res.partner"].search([("name", "=", order.get("partner_id"))], limit=1)
+            vals = {
+                "partner_id": partner.id,
+                "warehouse_id": self.warehouse_id.id,
+                "order_line": [],
+            }
+            sale_order = SaleOrder.create(vals)
+            sale_order.action_confirm()
+


### PR DESCRIPTION
## Summary
- add new module pos_sale_interconnector with manifest and models
- describe usage in README

## Testing
- `python -m py_compile pos_sale_interconnector/models/interconnector.py`
- `python -m compileall pos_sale_interconnector`


------
https://chatgpt.com/codex/tasks/task_e_684000ea5bac83239464d0f0a2b7630b